### PR TITLE
Download nltk data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN chmod +x boot.sh
 RUN echo "source /venv/bin/activate" > ~/.bashrc
 ENV PATH /venv/bin:$PATH
 
+RUN [ "python3", "-c", "import nltk; nltk.download('punkt', download_dir='/root/nltk_data')" ]
+
 EXPOSE 5000
 
 ENTRYPOINT ["./boot.sh"]


### PR DESCRIPTION
Download nltk data when building image so container can be used without public internet access.